### PR TITLE
Don't trigger react-native error handler

### DIFF
--- a/src/development.js
+++ b/src/development.js
@@ -13,7 +13,15 @@ export default function catchErrors({ filename, components, imports }) {
       try {
         return originalRender.apply(this, arguments);
       } catch (err) {
-        console.error(err);
+        if (console.reportErrorsAsExceptions) {
+          // Stop react-native from triggering it's own error handler
+          console.reportErrorsAsExceptions = false;
+          console.error(err);
+          // Reactivate it so other errors are still handled
+          console.reportErrorsAsExceptions = true;
+        } else {
+          console.error(err);
+        }
         return React.createElement(ErrorReporter, {
           error: err
         });


### PR DESCRIPTION
react-native captures console.error calls and displays it's own
exception handler. This behaviour can be disabled by setting
console.reportErrorsAsExceptions to false. Add check for this flag and
temporarily disable it.
