### PR TITLE
pass filename to <ErrorReporter/>

### DIFF
--- a/src/development.js
+++ b/src/development.js
@@ -23,7 +23,8 @@ export default function catchErrors({ filename, components, imports }) {
           console.error(err);
         }
         return React.createElement(ErrorReporter, {
-          error: err
+          error: err,
+          filename
         });
       }
     };


### PR DESCRIPTION
As discussed in https://github.com/jedwards1211/meteor-webpack-react/issues/40#issuecomment-140234107, the stack trace `redbox-react` prints doesn't have source maps applied when `devtool` is `'source-map'`.  `console.error(error.stack)` prints out the original file names and locations from the source map; I'm not yet sure if it uses something special that `error-stack-parser` could easily call, but `react-transform-catch-errors` can at least pass the filename to the `ErrorHandler`.
