### PR TITLE
update readme with hinting for document.body rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ It must be an array of the transforms you want to use:
 
 **It is up to you to ensure that the transform is not enabled when you compile the app in production mode.** The easiest way to do this is to put React Transform configuration inside `env.development` in `.babelrc` and ensure you’re calling `babel` with `NODE_ENV=production`. See [babelrc documentation](https://babeljs.io/docs/usage/babelrc/#env-option) for more details about using `env` option.
 
+## Hints
+
+Make sure your react-app is not attached to `document.body` as the client-overlay will render into `document.body`.
+Attaching the react root-node to `document.body` requires extra caution, as many third-party packages will append their markup to the body as well. React will replace the entire contents in the body on every re-render. Thus you will not see the additional markup.
+Better provide a `#root`-Element.
+
+```js
+import React from 'react'
+import { App } from 'app'
+
+React.render(<App />, document.getElementById('root'))
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
Hi guys,

I spent more than two days figuring out why the errors were printed to the console, but did not render in the client-overlay. This is because my react app was directly attached to `document.body`.
I suggest to update the readme so others out there don't struggle with the same issue.

Regards,
Sven
