### PR TITLE
fix example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ It must be an array of the transforms you want to use:
 }
 ```
 
-**It is up to you to ensure that the transform is not enabled when you compile the app in production mode.** The easiest way to do this is to put React Transform configuration inside `env.development` in `.babelrc` and ensure you’re calling `babel` with `NODE_ENV=production`. See [babelrc documentation](https://babeljs.io/docs/usage/babelrc/#env-option) for more details about using `env` option.
+**It is up to you to ensure that the transform is not enabled when you compile the app in production mode.** The easiest way to do this is to put React Transform configuration inside `env.development` in `.babelrc` and ensure you’re calling `babel` with `NODE_ENV=development`. See [babelrc documentation](https://babeljs.io/docs/usage/babelrc/#env-option) for more details about using `env` option.
 
 ## License
 


### PR DESCRIPTION
Should be `NODE_ENV=development` not `NODE_ENV=production`
