### PR TITLE
Add more information to error handler.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ export default function catchErrors({ filename, components, imports }) {
           error: err,
           filename,
           componentName: ReactClass.displayName,
+          componentState: this.state,
+          componentProps: this.props,
           ...reporterOptions
         });
       }

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ export default function catchErrors({ filename, components, imports }) {
         return React.createElement(ErrorReporter, {
           error: err,
           filename,
+          componentName: ReactClass.displayName,
           ...reporterOptions
         });
       }


### PR DESCRIPTION
At Taskworld we’re using this in production to be able to catch React rendering errors and display a graceful error message in a web app, and also to send an object containing props and state (stripped of sensitive data) to an error tracking system.

This PR adds several addition props to pass to `ErrorReporter`:
- `componentName` The `displayName` of the component that crashed.
- `componentState` The state object of the component that crashed.
- `componentProps` The props passed to the component that crashed.

(Previously, I’ve been monkeypatching `React.createClass` to augment `render()` method with a try...catch block. Moving towards ES6 components, such monkeypatching isn’t possible anymore.)
